### PR TITLE
Guard against getting unknown property. 

### DIFF
--- a/src/CookieConsentBanner.php
+++ b/src/CookieConsentBanner.php
@@ -23,6 +23,7 @@ use craft\web\twig\variables\CraftVariable;
 use craft\web\View;
 use craft\db\Query;
 use craft\db\Table;
+use craft\elements\Entry;
 
 use yii\base\Event;
 
@@ -155,7 +156,7 @@ class CookieConsentBanner extends Plugin
 	      View::EVENT_BEFORE_RENDER_TEMPLATE,
 	      function (TemplateEvent $event) {
 		    $settings = $this->getSettings();
-		    if(isset($event->variables['entry'])) {
+		    if(isset($event->variables['entry']) && $event->variables['entry'] instanceof Entry) {
 		      $entryTypeUid = (new Query())
                 ->select(['uid'])
                 ->from([Table::ENTRYTYPES])


### PR DESCRIPTION
```
[yii\base\UnknownPropertyException] yii\base\UnknownPropertyException: Getting unknown property: barrelstrength\sproutforms\elements\Entry::type in /app/vendor/yiisoft/yii2/base/Component.php:154
```

This has been mentioned on the Sprout Forms GitHub, but doesn't look like it ever made it here. 

See the conversation here: https://github.com/barrelstrength/craft-sprout-forms/issues/420