### PR TITLE
Add Craft 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0"
+        "craftcms/cms": "^5.0.0",
+        "php": "^8.0.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/migrations/m190902_000000_migrate_settings_to_uid.php
+++ b/src/migrations/m190902_000000_migrate_settings_to_uid.php
@@ -5,8 +5,8 @@ use Craft;
 use craft\db\Migration;
 use craft\db\Query;
 use craft\db\Table;
-use craft\helpers\MigrationHelper;
-use craft\services\Plugins;
+use craft\services\ProjectConfig;
+
 class m190902_000000_migrate_settings_to_uid extends Migration
 {
     // Public Methods
@@ -39,7 +39,7 @@ class m190902_000000_migrate_settings_to_uid extends Migration
             }
         }
         // Update the plugin's settings in the project config
-        Craft::$app->getProjectConfig()->set(Plugins::CONFIG_PLUGINS_KEY . '.' . $plugin->handle . '.settings', $settings->toArray());
+        Craft::$app->getProjectConfig()->set(ProjectConfig::PATH_PLUGINS . '.' . $plugin->handle . '.settings', $settings->toArray());
     }
     public function safeDown() : bool
     {

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -307,7 +307,7 @@
   }) }}
   <hr>
   {% set allEntryTypes = {} %}
-  {% for section in craft.app.sections.allSections %}
+  {% for section in craft.app.entries.allSections %}
     {% for entryType in section.getEntryTypes() %}
       {% set allEntryTypes = allEntryTypes|merge([{ value: entryType.uid, label: entryType.name }]) %}
     {% endfor %}


### PR DESCRIPTION
As the plugin is mostly just JS + settings in Craft, adding Craft 5 compatibility was a doddle...

1. Ran [rector + craft 5 rules](https://github.com/craftcms/rector)
2. Fixed template reference to old `sections` service => `entries` instead (breaking change)
3. Cleaned up a migration (should still work on C4 too)